### PR TITLE
Include RFQ-IDs in QA script and only print error codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "@hashflow/sdk": "^1.2.4",
-    "@hashflow/taker-js": "^0.0.2",
+    "@hashflow/taker-js": "^0.0.4",
     "bignumber.js": "^9.1.1",
     "ethers": "5.7.0",
     "yargs": "^17.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,10 +24,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eth-optimism/contracts-bedrock@0.11.3":
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts-bedrock/-/contracts-bedrock-0.11.3.tgz#102c4de7d741f28bf7ee23ac7866660a0eb40a9e"
-  integrity sha512-WOP69fdv7TIfvTD6pEedW0OVwYe39aX2DXqvKDpDhJNF0W9miHZUY7UaNKiSqlE37SuQJpC4VvGfls/gwfL1Mw==
+"@eth-optimism/contracts-bedrock@0.11.4":
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts-bedrock/-/contracts-bedrock-0.11.4.tgz#6c3ef886b6a5f671fcfd7d749eee20d91633fe93"
+  integrity sha512-aUjSEwaxQ2UySgR4vi9b2+zH1OLZfoR1XHQaIWOfeINp9WEQ8qTUnaYiuCjdyPKv09wrXQlU6HqfDV/s0o8SgA==
   dependencies:
     "@eth-optimism/core-utils" "^0.12.0"
     "@openzeppelin/contracts" "4.7.3"
@@ -67,12 +67,12 @@
     chai "^4.3.4"
 
 "@eth-optimism/sdk@^1.6.2":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-1.10.1.tgz#843384985f00e443d6ab1252fa566cdd8421773e"
-  integrity sha512-ypoHVeMZo+PHgujsp2n/LTxkAOHM1P4gmDf1JigGNdQlelu9/83eYQPr9BYHDaYETvCi1YKTmjnT+tqqqVGLeg==
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-1.10.2.tgz#cbbac2c5c454bc01650d72b5c8fecf4f7d9e4531"
+  integrity sha512-g/WyKrB0K9fBXu2fjegtkq/kvogZBggTYVjb4SMKM4wPIAkll/Qdvib48Pjvb8Ybe7JmezXx29yRe1KjPsqXkw==
   dependencies:
     "@eth-optimism/contracts" "0.5.40"
-    "@eth-optimism/contracts-bedrock" "0.11.3"
+    "@eth-optimism/contracts-bedrock" "0.11.4"
     "@eth-optimism/core-utils" "0.12.0"
     lodash "^4.17.21"
     merkletreejs "^0.2.27"
@@ -484,7 +484,20 @@
     "@openzeppelin/contracts" "^4.7.3"
     "@openzeppelin/contracts-upgradeable" "^4.7.3"
 
-"@hashflow/sdk@^1.0.1", "@hashflow/sdk@^1.2.4":
+"@hashflow/sdk@^1.0.1":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@hashflow/sdk/-/sdk-1.2.5.tgz#e27d7c0ef01ec595a3b3e0594124d98b9a76c1ca"
+  integrity sha512-lLoHN7bLifdyYN3RZf3rqk0uqTX3bxj2j0Z3bA2GzhHtwtleq0/EbEyns5OsNk1aaWbJzUU0xSfHsB51qJ6sGA==
+  dependencies:
+    "@eth-optimism/sdk" "^1.6.2"
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/providers" "^5.7.0"
+    "@hashflow/governance" "1.0.4"
+    "@hashflow/hashverse-contracts" "1.0.2"
+    "@hashflow/protocol" "1.0.3"
+
+"@hashflow/sdk@^1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@hashflow/sdk/-/sdk-1.2.4.tgz#edf2d7208d04e6bee1bf69aeaa7df68156db30b1"
   integrity sha512-gEhRudo8e3x3lwzdsfZfhXQHE0C63sH8tcHIT2K/L6sEPUkIz7jbTkfQFaiDVcpGjvUDlCKCEjqGHWE8btnk7Q==
@@ -497,10 +510,10 @@
     "@hashflow/hashverse-contracts" "1.0.2"
     "@hashflow/protocol" "1.0.3"
 
-"@hashflow/taker-js@^0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@hashflow/taker-js/-/taker-js-0.0.2.tgz#cadcd396ab29ce2fab1cb94f8a2b6f9bc8658c54"
-  integrity sha512-3Yly8Eglvs06OpVbnBcNDBfPSmkEiJRSA8HsBwbPrfppagFOnzLCs6Z0U4A8Ztdnic4rbWVokb7r5YEJ0TxgWg==
+"@hashflow/taker-js@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@hashflow/taker-js/-/taker-js-0.0.4.tgz#affd49b2286ae47b6bd4db1cd9328a75328a4c84"
+  integrity sha512-NEc1qIX/vbuTjBlEuoOuVF/oUaWc9XuERl2BzpIlt82PD5XYxeS3c/eKO5NEp43b+OuO2+IuOPfModV9jx49QA==
   dependencies:
     "@hashflow/sdk" "^1.0.1"
     axios "^0.27.2"
@@ -3981,9 +3994,9 @@ unbox-primitive@^1.0.2:
     which-boxed-primitive "^1.0.2"
 
 undici@^5.14.0:
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.18.0.tgz#e88a77a74d991a30701e9a6751e4193a26fabda9"
-  integrity sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==
+  version "5.19.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.19.1.tgz#92b1fd3ab2c089b5a6bd3e579dcda8f1934ebf6d"
+  integrity sha512-YiZ61LPIgY73E7syxCDxxa3LV2yl3sN8spnIuTct60boiiRaE1J8mNWHO8Im2Zi/sFrPusjLlmRPrsyraSqX6A==
   dependencies:
     busboy "^1.6.0"
 


### PR DESCRIPTION
This PR includes two changes to the QA script logs
1. Include **internal RFQ-IDs** in the text
2. Adjust error messages to only show the error. This is so that we don't print the `inboundRfqId` and confuse users.

## Testing
Ran `qa` locally. We haven't deployed the `internalRfqIds` change to scuderia so none of the RFQ-IDs show up yet.

```
Success rate: 40.00%  Avg bias: -10.55 bps  Std deviation: 1.626 bps
Min level: 30.009 DAI  Max level: 295,332.8 DAI

[P] = Provided in RFQ   [M] = Received from Maker
[00] [--]  [M] base: 219,843.21 DAI  [P] quote: 131.33434 ETH  expected: 220,088.94 DAI  diff:     -11.2 bps  fees: 1 bps  
[01] [--]  [M] base: 275,112.49 DAI  [P] quote: 164.22947 ETH  expected: 275,362.13 DAI  diff: undefined bps  fees: 6 bps  failed! No quote data. Received error: {"code":76,"message":"Exceeds supported amounts"}
[02] [--]  [P] base: 277,196.49 DAI  [M] quote: 165.47331 ETH  expected:  165.29022 ETH  diff: undefined bps  fees: 8 bps  failed! No quote data. Received error: {"code":76,"message":"Exceeds supported amounts"}
[03] [--]  [P] base:  73,432.09 DAI  [M] quote:  43.84094 ETH  expected:   43.79757 ETH  diff: undefined bps  fees: 7 bps  failed! No quote data. Received error: {"code":76,"message":"Exceeds supported amounts"}
[04] [--]  [M] base: 153,403.30 DAI  [P] quote:  91.62652 ETH  expected: 153,586.14 DAI  diff:     -11.9 bps  fees: 4 bps  
[05] [--]  [P] base:  51,948.90 DAI  [M] quote:  31.01516 ETH  expected:   31.00010 ETH  diff: undefined bps  fees: 2 bps  failed! No quote data. Received error: {"code":76,"message":"Exceeds supported amounts"}
[06] [--]  [M] base: 137,461.02 DAI  [P] quote:  82.06506 ETH  expected: 137,516.10 DAI  diff: undefined bps  fees: 1 bps  failed! No quote data. Received error: {"code":76,"message":"Exceeds supported amounts"}
[07] [--]  [P] base: 192,780.03 DAI  [M] quote: 115.15941 ETH  expected:  115.02879 ETH  diff:     -11.4 bps  fees: 2 bps  
[08] [--]  [M] base: 217,918.14 DAI  [P] quote: 130.11914 ETH  expected: 218,087.50 DAI  diff:     -7.77 bps  fees: 6 bps  
[09] [--]  [P] base:  94,530.35 DAI  [M] quote:  56.43650 ETH  expected:   56.40863 ETH  diff: undefined bps  fees: 2 bps  failed! No quote data. Received error: {"code":76,"message":"Exceeds supported amounts"}

```