### PR TITLE
Add /marketMakers 'marketMaker' field

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "@hashflow/sdk": "^1.2.4",
-    "@hashflow/taker-js": "^0.0.4",
+    "@hashflow/taker-js": "^0.0.6",
     "bignumber.js": "^9.1.1",
     "ethers": "5.7.0",
     "yargs": "^17.6.2"

--- a/src/scripts/qa.ts
+++ b/src/scripts/qa.ts
@@ -64,7 +64,11 @@ async function handler(): Promise<void> {
   process.stdout.write('Finding active makers ... ');
   const makers: string[] = [];
   try {
-    const chainMakers = await hashflow.getMarketMakers(chainId);
+    const chainMakers = await hashflow.getMarketMakers(
+      chainId,
+      undefined,
+      maker
+    );
     for (const externalMaker of chainMakers) {
       const makerPrefix = externalMaker.split('_')[0];
       if (makerPrefix === maker) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,10 +510,10 @@
     "@hashflow/hashverse-contracts" "1.0.2"
     "@hashflow/protocol" "1.0.3"
 
-"@hashflow/taker-js@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@hashflow/taker-js/-/taker-js-0.0.4.tgz#affd49b2286ae47b6bd4db1cd9328a75328a4c84"
-  integrity sha512-NEc1qIX/vbuTjBlEuoOuVF/oUaWc9XuERl2BzpIlt82PD5XYxeS3c/eKO5NEp43b+OuO2+IuOPfModV9jx49QA==
+"@hashflow/taker-js@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@hashflow/taker-js/-/taker-js-0.0.6.tgz#b309428094a64434b96b5f011a216d564f500a40"
+  integrity sha512-cuftQ1boU5a3aC4clf/jWATP3FEgQ22FDvNxapDLvNXvSlUm2oOPEpogpsgq/4fLA9D+Cc2aMJtfwlrN6sdbNA==
   dependencies:
     "@hashflow/sdk" "^1.0.1"
     axios "^0.27.2"


### PR DESCRIPTION
We recently update the `/marketMakers` API to support authenticating makers when using `source: qa`. Unfortunately, I forgot to update the qa script with this, which resulted in maker authentication failing. 

## Testing
Tested this against our example maker using their keys and it worked correctly.