### PR TITLE
Fix the rfqId in qa script

### DIFF
--- a/src/scripts/qa.ts
+++ b/src/scripts/qa.ts
@@ -536,7 +536,7 @@ async function testRfqs(
         expectedAmount,
         deviationBps,
         feesBps,
-        rfqIds: rfq.internalRfqIds ?? [],
+        rfqIds: [rfq.rfqId] ?? [],
       };
     } catch (err) {
       return {


### PR DESCRIPTION
the script is not printing RfqId as the rfqid is returned in `rfqId` instead of `internalrfqIds` in response

Test Plan: Ran QA