### PR TITLE
Update QA to work with cross-chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@ To run this script, follow these steps:
 2. Navigate to `src/` and run `yarn`
 3. Copy `src/.env.example` to `src/.env` and set the environment variables:
     * ***`AUTH_KEY`***: Use your maker authorization key here. This is the same key you provide when connecting to our maker WebSocket.
-    * ***`QA_TAKER_ADDRESS`***: Put the EVM address of the wallet you want to use for testing. In the current iteration, no funds are transferred. This is just used to fill in the `trader` field in the RFQs you get.
+      * Wallets: In the current iteration, no funds are transferred. This is just used to fill in the `trader` field in the RFQs you get.
+        * ***`QA_TAKER_ADDRESS`***: Put the EVM address of the wallet you want to use for testing. 
+        * ***`QA_TAKER_ADDRESS_SOLANA`*** Put the Solana address of the wallet you want to use for testing. 
 4. Finally, run `yarn qa <options>` with the following options:
     * ***`--maker`***: your external maker name (e.g. `--maker=mm123`)
     * ***`--chain`***: chain id that you want to test (e.g. `--chain=137`)
+    * ***(Optional) `--chain_type`***: chain type to test (either `evm` or `solana`. Default: `evm`)
+    * ***(Optional) `--quote_chain`***: quote chain to test. If not set, we will use the base_chain.
+    * ***(Optional) `--quote_chain_type`***: quote chain type to test. If not set, we will use the base_chain_type.
+    * ***(Optional) `--check_all_xchain`***: if true, request quotes for all intra-chain and cross-chain quotes available for the provided base chain. (Default: `false`)
     * ***(Optional) `--base_token`***: base token name if you want to only test a specific pair (e.g. `--base_token=ETH`). If this is set, you also need to provide `--quote_token`. If this is not set, we'll test all pairs on the provided `chain`.
     * ***(Optional) `--quote_token`***: quote token name if you want to only test a specific pair (e.g. `--quote_token=ETH`). If this is set, you also need to provide `--base_token`. If this is not set, we'll test all pairs on the provided `chain`.
     * ***(Optional) `--env`***: Environment to test against. Default is `--env=staging`, the other option is `--env=production`. This will route your requests against `api-staging.hashflow.com` or `api.hashflow.com` respectively.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ To run this script, follow these steps:
     * ***`--chain`***: chain id that you want to test (e.g. `--chain=137`)
     * ***(Optional) `--chain_type`***: chain type to test (either `evm` or `solana`. Default: `evm`)
     * ***(Optional) `--quote_chain`***: quote chain to test. If not set, we will use the base_chain.
-    * ***(Optional) `--quote_chain_type`***: quote chain type to test. If not set, we will use the base_chain_type.
+    * ***(Optional) `--quote_chain_type`***: quote chain type to test. (Default: 'evm')
     * ***(Optional) `--check_all_xchain`***: if true, request quotes for all intra-chain and cross-chain quotes available for the provided base chain. (Default: `false`)
     * ***(Optional) `--base_token`***: base token name if you want to only test a specific pair (e.g. `--base_token=ETH`). If this is set, you also need to provide `--quote_token`. If this is not set, we'll test all pairs on the provided `chain`.
     * ***(Optional) `--quote_token`***: quote token name if you want to only test a specific pair (e.g. `--quote_token=ETH`). If this is set, you also need to provide `--base_token`. If this is not set, we'll test all pairs on the provided `chain`.
     * ***(Optional) `--env`***: Environment to test against. Default is `--env=staging`, the other option is `--env=production`. This will route your requests against `api-staging.hashflow.com` or `api.hashflow.com` respectively.
     * ***(Optional) `--num_requests`***: Number of RFQs to send for each pair. Default is `--num_requests=30`.
-    * ***(Optional) `--delay-ms`***: Delay to introduce between each RFQ in milliseconds. This can be useful to test pricing skew over a longer period of time. Default is `--delay_ms=0`.
+    * ***(Optional) `--delay_ms`***: Delay to introduce between each RFQ in milliseconds. This can be useful to test pricing skew over a longer period of time. Default is `--delay_ms=0`.
     
 #### Interpreting the results
 When running the script, you're going to see output in the terminal that looks something like this (slightly edited version):

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.418.0",
     "@hashflow/sdk": "^1.2.4",
-    "@hashflow/taker-js": "^0.3.5",
+    "@hashflow/taker-js": "../taker-js",
     "bignumber.js": "^9.1.1",
     "ethers": "6.7.0",
     "yargs": "^17.6.2"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.418.0",
     "@hashflow/sdk": "^1.2.4",
-    "@hashflow/taker-js": "../taker-js",
+    "@hashflow/taker-js": "^0.3.6",
     "bignumber.js": "^9.1.1",
     "ethers": "6.7.0",
     "yargs": "^17.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -929,8 +929,10 @@
     "@hashflow/hashverse-contracts-evm" "1.0.0"
     "@hashflow/protocol" "1.0.3"
 
-"@hashflow/taker-js@../taker-js":
-  version "0.3.5"
+"@hashflow/taker-js@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@hashflow/taker-js/-/taker-js-0.3.6.tgz#17a30ab037d8ce327a4e4fea3604e3475dc48a21"
+  integrity sha512-qLvvjQMFAW7HyOldLpm5ixn+ND2e4comw1opUup4KnwDAXs5gJK6DDD8gCUn8hfLL/4JsB8vcikywKIVQ5U3qQ==
   dependencies:
     "@hashflow/sdk" "^2.2.0"
     "@solana/web3.js" "^1.87.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -929,10 +929,8 @@
     "@hashflow/hashverse-contracts-evm" "1.0.0"
     "@hashflow/protocol" "1.0.3"
 
-"@hashflow/taker-js@^0.3.5":
+"@hashflow/taker-js@../taker-js":
   version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@hashflow/taker-js/-/taker-js-0.3.5.tgz#69e3af6e0e4a9f429cf9877bbc5171a30d2b4e18"
-  integrity sha512-v1OpsNITaGUZyMcSPYu1P/06Ld7/yc9NeACxBiAn4NhdzJCGtO3a8APhIjUiNRcqeEITk2X/YWOt6VIRl0t6Wg==
   dependencies:
     "@hashflow/sdk" "^2.2.0"
     "@solana/web3.js" "^1.87.5"


### PR DESCRIPTION
Update the QA script to work with cross-chain. This change adds a few commandline arguments and updates documentation:

```
--quote_chain
--quote_chain_type
--check_all_xchain
```

Note that this change also renames the argument `chainType` to `chain_type` to fit the pattern of other arguments better. 

With this change if you pass in a `--quote_chain` it will request quotes for that quote chain. If `--check_all_xchain` is passed in, then the script will call the `getTradingPairs` endpoint to determine all the available quote chains, and request quotes for all available quote chains. If both are passed in, an error results, if neither are passed in, only intra-chain quotes are requested.

This requires [the changes to taker-js in this PR](https://github.com/hashflownetwork/taker-js/pull/13). 

Test plan:

Using the `taker-js` PR above, ran the following:

```
yarn qa --maker=mm27 --env=staging --chain=1000002 --chain_type=solana --quote_chain_type=evm --quote_chain=5 --num_requests=1
yarn qa --maker=mm27 --env=staging --chain=1000002 --chain_type=solana --quote_chain_type=solana --quote_chain=1000002 --num_requests=1
yarn qa --maker=mm27 --env=staging --chain=1000002 --chain_type=solana --check_all_xchain --num_requests=1
yarn qa --maker=mm27 --env=staging --chain=1000002 --chain_type=solana --check_all_xchain --num_requests=1 --quote_chain=5
yarn qa --maker=mm27 --env=staging --chain=5 --chain_type=evm --quote_chain_type=solana --quote_chain=1000002 --num_requests=1
```

All gave results as expected. Note that we did not receive cross-chain quotes because mm27 is not properly quoting cross-chain yet.