### PR TITLE
Do round-trip RFQs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ To run this script, follow these steps:
     * ***(Optional) `--env`***: Environment to test against. Default is `--env=staging`, the other option is `--env=production`. This will route your requests against `api-staging.hashflow.com` or `api.hashflow.com` respectively.
     * ***(Optional) `--num_requests`***: Number of RFQs to send for each pair. Default is `--num_requests=30`.
     * ***(Optional) `--delay_ms`***: Delay to introduce between each RFQ in milliseconds. This can be useful to test pricing skew over a longer period of time. Default is `--delay_ms=0`.
+    * ***(Optional) `--round_trips`***: After receiving a quote, send another quote request with the received amount to check parity with provided amount.
     
 #### Interpreting the results
 When running the script, you're going to see output in the terminal that looks something like this (slightly edited version):

--- a/src/scripts/qa.ts
+++ b/src/scripts/qa.ts
@@ -16,6 +16,7 @@ const parser = yargs(process.argv.slice(2)).options({
   env: { string: true, default: 'staging' },
   num_requests: { number: true, default: 30 },
   delay_ms: { number: true, default: 0 },
+  round_trips: { boolean: true, default: false },
 });
 
 async function getAuthKey(): Promise<{ name: string; key: string }> {
@@ -74,6 +75,7 @@ async function main() {
       chain,
       quoteChain,
       argv.check_all_xchain,
+      argv.round_trips,
       argv.base_token,
       argv.quote_token,
       evmQaAddress,


### PR DESCRIPTION
A helpful thing to look at may be to see if you provide a basetoken amount, get back a quotetoken amount, and then do a second rfq with the quote token amount, do you get back the base token amount? You should modulo fees. (Later we can add some analysis of this round-trip to take into account fees.)

Test excerpt:

```
[00] ["0x21d100000000000000000000000000ffffffffffffff001cfce30367c77b0000"]  [M] base: 36.014616 USDC  [P] quote: 36.349301 USDT  expected: 36.742185 USDC  roundTrip: 36.349301 USDT diff: -198 bps  fees:  7 bps
[01] ["0x21d100000000000000000000000000ffffffffffffff001cfce303a9c77b0000"]  [M] base:  2.406401 USDC  [P] quote:  2.429249 USDT  expected:  2.455015 USDC  roundTrip:  2.429250 USDT diff: -198 bps  fees:  5 bps
[02] ["0x21d100000000000000000000000000ffffffffffffff001cfce303acc77b0000"]  [P] base: 68.548361 USDC  [M] quote: 66.167047 USDT  expected: 66.167048 USDT  roundTrip: 68.548362 USDC diff:    0 bps  fees:  4 bps
[03] ["0x21d100000000000000000000000000ffffffffffffff001cfce30383c77b0000"]  [M] base: 58.445677 USDC  [P] quote: 59.738813 USDT  expected: 61.425600 USDC  roundTrip: 59.738814 USDT diff: -485 bps  fees:  8 bps
[04] ["0x21d100000000000000000000000000ffffffffffffff001cfce30379c77b0000"]  [P] base: 63.485593 USDC  [M] quote: 61.612378 USDT  expected: 61.612379 USDT  roundTrip: 63.485593 USDC diff:    0 bps  fees:  4 bps
[05] ["0x21d100000000000000000000000000ffffffffffffff001cfce303bac77b0000"]  [P] base: 11.000406 USDC  [M] quote: 10.886045 USDT  expected: 10.886046 USDT  roundTrip: 11.000407 USDC diff:    0 bps  fees:  4 bps
[06] ["0x21d100000000000000000000000000ffffffffffffff001cfce303bac77b0001"]  [P] base:  7.540052 USDC  [M] quote:  7.461665 USDT  expected:  7.461665 USDT  roundTrip:  7.540052 USDC diff:    0 bps  fees:  4 bps
[07] ["0x21d100000000000000000000000000ffffffffffffff001cfce30436c77b0000"]  [P] base: 52.972035 USDC  [M] quote: 52.159179 USDT  expected: 52.159179 USDT  roundTrip: 52.972036 USDC diff:    0 bps  fees:  3 bps
```
